### PR TITLE
Fix ResourceController to provision Cloudant

### DIFF
--- a/examples/resourcecontrollerv2/resource-instance-cloudant.yaml
+++ b/examples/resourcecontrollerv2/resource-instance-cloudant.yaml
@@ -1,0 +1,15 @@
+apiVersion: resourcecontrollerv2.ibm-cloud.crossplane.io/v1alpha1
+kind: ResourceInstance
+metadata:
+  name: mycloudant
+spec:
+  forProvider:
+    name: mycloudant
+    target: us-south
+    resourceGroupName: default
+    serviceName: cloudantnosqldb
+    resourcePlanName: standard
+    tags:
+      - dev
+  providerConfigRef:
+    name: ibm-cloud

--- a/pkg/clients/ibmcloud_helpers.go
+++ b/pkg/clients/ibmcloud_helpers.go
@@ -85,7 +85,14 @@ func getPlanEntries(client ClientSession, serviceName string) (*gcat.EntrySearch
 		return nil, errors.New(errNotFound)
 	}
 
-	id := svcEntries.Resources[0].Metadata.Ui.PrimaryOfferingID
+	var id *string
+    id = svcEntries.Resources[0].Metadata.Ui.PrimaryOfferingID
+
+    // Some Catalog Entries (i.e. Cloudant) do not set UI
+    // Metadata ID. Use Resource ID attribute in this case.
+    if id == nil {
+        id = svcEntries.Resources[0].ID
+    }
 
 	getChildOptions := &gcat.GetChildObjectsOptions{
 		ID:   id,

--- a/pkg/clients/ibmcloud_helpers.go
+++ b/pkg/clients/ibmcloud_helpers.go
@@ -86,13 +86,13 @@ func getPlanEntries(client ClientSession, serviceName string) (*gcat.EntrySearch
 	}
 
 	var id *string
-    id = svcEntries.Resources[0].Metadata.Ui.PrimaryOfferingID
+	id = svcEntries.Resources[0].Metadata.Ui.PrimaryOfferingID
 
-    // Some Catalog Entries (i.e. Cloudant) do not set UI
-    // Metadata ID. Use Resource ID attribute in this case.
-    if id == nil {
-        id = svcEntries.Resources[0].ID
-    }
+	// Some Catalog Entries (i.e. Cloudant) do not set UI
+	// Metadata ID. Use Resource ID attribute in this case.
+	if id == nil {
+		id = svcEntries.Resources[0].ID
+	}
 
 	getChildOptions := &gcat.GetChildObjectsOptions{
 		ID:   id,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #22 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
A ResourceInstance YAML for Cloudant was created and used to test the handling of the controller to provision a corresponding Cloudant instance in IBM Cloud. The YAML was applied using the standard `kubectl apply -f <file>` command and the resulting resource was confirmed to be provisioned in the appropriate IBM Cloud Account.
 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
