### PR TITLE
Update version of platform-services SDK to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20201019071904-51caa09553fb
 	github.com/IBM/experimental-go-sdk v0.0.0-20210112204617-192fc5b15655
 	github.com/IBM/go-sdk-core v1.1.0
-	github.com/IBM/go-sdk-core/v4 v4.9.0
-	github.com/IBM/platform-services-go-sdk v0.17.4
+	github.com/IBM/go-sdk-core/v4 v4.10.0
+	github.com/IBM/go-sdk-core/v5 v5.2.0 // indirect
+	github.com/IBM/platform-services-go-sdk v0.17.18
 	github.com/crossplane/crossplane-runtime v0.11.1-0.20201116232334-1b691efff491
 	github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb
 	github.com/go-openapi/strfmt v0.19.11

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,14 @@ github.com/IBM/go-sdk-core v1.1.0 h1:pV73lZqr9r1xKb3h08c1uNG3AphwoV5KzUzhS+pfEqY
 github.com/IBM/go-sdk-core v1.1.0/go.mod h1:2pcx9YWsIsZ3I7kH+1amiAkXvLTZtAq9kbxsfXilSoY=
 github.com/IBM/go-sdk-core/v4 v4.9.0 h1:OkSg5kaEfVoNuBA4IsIOz8Ur5rbGHbWxmWCZ7nK/oc0=
 github.com/IBM/go-sdk-core/v4 v4.9.0/go.mod h1:DbQ+3pFoIjxGGTEiA9zQ2V0cemMNmFMkLBBnR729HKg=
-github.com/IBM/platform-services-go-sdk v0.17.4 h1:V6EGnYQh9Tw8/LVMDAX6EdKbjlh7xvrvF4W/HF8cl+c=
-github.com/IBM/platform-services-go-sdk v0.17.4/go.mod h1:ez3yDwaaa1+aqzaMOPUwjwkOMjdkmtVyMqyE+/Yx7AI=
+github.com/IBM/go-sdk-core/v4 v4.10.0 h1:aLoKusSFVsxMJeKHf8csj9tBWt4Y50kVvfxoKh6scN0=
+github.com/IBM/go-sdk-core/v4 v4.10.0/go.mod h1:0uz2ca0MZ2DwsBRGl9Jp3EaCTqxmKZTdvV/CkCB7JnI=
+github.com/IBM/go-sdk-core/v5 v5.0.0 h1:XB78PXwPVkhPBwESiK7cU5owMw9LMU1xyDMDajuNcJk=
+github.com/IBM/go-sdk-core/v5 v5.0.0/go.mod h1:vyNdbFujJtdTj9HbihtvKwwS3k/GKSKpOx9ZIQ6MWDY=
+github.com/IBM/go-sdk-core/v5 v5.2.0 h1:fVqzyAh9AiEOOcKZHVClmaH78qiYdxcUArP/27yo/l8=
+github.com/IBM/go-sdk-core/v5 v5.2.0/go.mod h1:vyNdbFujJtdTj9HbihtvKwwS3k/GKSKpOx9ZIQ6MWDY=
+github.com/IBM/platform-services-go-sdk v0.17.18 h1:rI1Kqc7c+KmqE1MoXJh+Lhi/3EW5WfXi+53H3AEK+rg=
+github.com/IBM/platform-services-go-sdk v0.17.18/go.mod h1:MSg7VY5MecPRSClxTAD9kLlSIOur4vTjpbJZW9NCMDA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/clients/ibmcloud.go
+++ b/pkg/clients/ibmcloud.go
@@ -497,11 +497,11 @@ func ExtractErrorMessage(resp *corev4.DetailedResponse, err error) error {
 }
 
 // GetEtag gets the Etag from a detailed response
-func GetEtag(resp *corev4.DetailedResponse) string {
-	if resp.Headers == nil {
+func GetEtag(headers http.Header) string {
+	if headers == nil {
 		return ""
 	}
-	return resp.Headers.Get("Etag")
+	return headers.Get("Etag")
 }
 
 // GetEtagAnnotation returns the etag annotation value on the resource.

--- a/pkg/controller/iamaccessgroupsv2/accessgroup.go
+++ b/pkg/controller/iamaccessgroupsv2/accessgroup.go
@@ -126,7 +126,7 @@ func (c *agExternal) Observe(ctx context.Context, mg resource.Managed) (managed.
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(ibmc.IsResourceNotFound, err), errGetAccessGroupFailed)
 	}
-	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp))
+	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp.Headers))
 
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	if err = ibmcag.LateInitializeSpec(&cr.Spec.ForProvider, instance); err != nil {

--- a/pkg/controller/iamaccessgroupsv2/accessgrouprule.go
+++ b/pkg/controller/iamaccessgroupsv2/accessgrouprule.go
@@ -124,7 +124,7 @@ func (c *agrExternal) Observe(ctx context.Context, mg resource.Managed) (managed
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(ibmc.IsResourceNotFound, err), errGetAccessGroupRuleFailed)
 	}
-	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp))
+	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp.Headers))
 
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	if err = ibmcagr.LateInitializeSpec(&cr.Spec.ForProvider, instance); err != nil {

--- a/pkg/controller/iamaccessgroupsv2/groupmembership.go
+++ b/pkg/controller/iamaccessgroupsv2/groupmembership.go
@@ -121,7 +121,7 @@ func (c *gmExternal) Observe(ctx context.Context, mg resource.Managed) (managed.
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(ibmc.IsResourceNotFound, err), errGetGroupMembershipFailed)
 	}
-	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp))
+	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp.Headers))
 
 	if len(instance.Members) == 0 {
 		return managed.ExternalObservation{

--- a/pkg/controller/iampolicymanagementv1/customrole.go
+++ b/pkg/controller/iampolicymanagementv1/customrole.go
@@ -121,7 +121,7 @@ func (c *crExternal) Observe(ctx context.Context, mg resource.Managed) (managed.
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(ibmc.IsResourceNotFound, err), errGetCustomRoleFailed)
 	}
-	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp))
+	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp.Headers))
 
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	if err = ibmccr.LateInitializeSpec(&cr.Spec.ForProvider, instance); err != nil {

--- a/pkg/controller/iampolicymanagementv1/policy.go
+++ b/pkg/controller/iampolicymanagementv1/policy.go
@@ -126,7 +126,7 @@ func (c *pExternal) Observe(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(ibmc.IsResourceNotFound, err), errGetPolicyFailed)
 	}
-	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp))
+	ibmc.SetEtagAnnotation(cr, ibmc.GetEtag(resp.Headers))
 
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	if err = ibmcp.LateInitializeSpec(&cr.Spec.ForProvider, instance); err != nil {


### PR DESCRIPTION
### Description of your changes

This PR updates the version of the IBM platform-services SDK to the most recent version.  This new version of the SDK includes new fields in the resource instance that we want to utilize.

Some small code changes were needed because of a minor incompatible change in the platform services SDK (allowed by semantic versioning because it is a release 0.x).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran `make test` and all tests pass.

[contribution process]: https://git.io/fj2m9
