### PR TITLE
Use default resource group ID if resource group name is not specified

### DIFF
--- a/pkg/clients/ibmcloud_helpers_test.go
+++ b/pkg/clients/ibmcloud_helpers_test.go
@@ -264,7 +264,7 @@ func TestGetResourcePlanName(t *testing.T) {
 
 func TestGetResourceGroupID(t *testing.T) {
 	type args struct {
-		rgName string
+		rgName *string
 	}
 	type want struct {
 		rgID *string
@@ -276,13 +276,19 @@ func TestGetResourceGroupID(t *testing.T) {
 	}{
 		"Found": {
 			args: args{
-				rgName: resourceGroupName,
+				rgName: &resourceGroupName,
+			},
+			want: want{rgID: &resourceGroupID, err: nil},
+		},
+		"Default": {
+			args: args{
+				rgName: nil,
 			},
 			want: want{rgID: &resourceGroupID, err: nil},
 		},
 		"NotFound": {
 			args: args{
-				rgName: invalidRGName,
+				rgName: &invalidRGName,
 			},
 			want: want{rgID: nil, err: errors.New(errRGIDNotFound)},
 		},

--- a/pkg/clients/resourceinstance/resourceinstance.go
+++ b/pkg/clients/resourceinstance/resourceinstance.go
@@ -62,7 +62,7 @@ func LateInitializeSpec(client ibmc.ClientSession, spec *v1alpha1.ResourceInstan
 
 // GenerateCreateResourceInstanceOptions produces CreateResourceInstanceOptions object from ResourceInstanceParameters object.
 func GenerateCreateResourceInstanceOptions(client ibmc.ClientSession, in v1alpha1.ResourceInstanceParameters, o *rcv2.CreateResourceInstanceOptions) error {
-	rgID, err := ibmc.GetResourceGroupID(client, in.ResourceGroupName)
+	rgID, err := ibmc.GetResourceGroupID(client, &in.ResourceGroupName)
 	if err != nil {
 		return errors.Wrap(err, errGetResGroupID)
 	}


### PR DESCRIPTION
Signed-off-by: Mike Kistler <mkistler@us.ibm.com>

### Description of your changes

This PR makes a small change to the helper method to lookup a resource group ID from a resource group name.  Since we want the resource group name to be an optional parameter for users, we need to allow the resource group name passed to this method to be a pointer so that `nil` can signify that the user did not provide a name.  In that case, we alter the lookup slightly to look only for default groups and return the first one.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have updated the unit tests to exercise the new path.

[contribution process]: https://git.io/fj2m9
