### PR TITLE
Generalized test utilities for global catalog

### DIFF
--- a/pkg/clients/resourceinstance/resourceinstance_test.go
+++ b/pkg/clients/resourceinstance/resourceinstance_test.go
@@ -206,8 +206,8 @@ func TestGenerateCreateResourceInstanceOptions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/resource_groups/", ibmc.RgTestHandler)
-			mux.HandleFunc("/", ibmc.SvcatTestHandler)
-			mux.HandleFunc("/"+ibmc.ServiceNameMockVal+"/", ibmc.PcatTestHandler)
+			mux.HandleFunc("/", ibmc.SvcatTestHandler(tc.args.params.ServiceName))
+			mux.HandleFunc("/"+tc.args.params.ServiceName+"/", ibmc.PcatTestHandler(tc.args.params.ResourcePlanName, *tc.want.instance.ResourcePlanID))
 			server := httptest.NewServer(mux)
 			defer server.Close()
 
@@ -261,8 +261,8 @@ func TestGenerateUpdateResourceInstanceOptions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/resource_groups/", ibmc.RgTestHandler)
-			mux.HandleFunc("/", ibmc.SvcatTestHandler)
-			mux.HandleFunc("/"+ibmc.ServiceNameMockVal+"/", ibmc.PcatTestHandler)
+			mux.HandleFunc("/", ibmc.SvcatTestHandler(tc.args.params.ServiceName))
+			mux.HandleFunc("/"+tc.args.params.ServiceName+"/", ibmc.PcatTestHandler(tc.args.params.ResourcePlanName, *tc.want.instance.ResourcePlanID))
 			server := httptest.NewServer(mux)
 			defer server.Close()
 
@@ -320,8 +320,8 @@ func TestResourceInstanceLateInitializeSpecs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/resource_groups/", ibmc.RgTestHandler)
-			mux.HandleFunc("/", ibmc.SvcatTestHandler)
-			mux.HandleFunc("/"+ibmc.ServiceNameMockVal+"/", ibmc.PcatTestHandler)
+			mux.HandleFunc("/", ibmc.SvcatTestHandler(tc.args.params.ServiceName))
+			mux.HandleFunc("/"+tc.args.params.ServiceName+"/", ibmc.PcatTestHandler(tc.args.params.ResourcePlanName, *tc.args.instance.ResourcePlanID))
 			mux.HandleFunc("/v3/tags/", ibmc.TagsTestHandler)
 			server := httptest.NewServer(mux)
 			defer server.Close()
@@ -417,8 +417,8 @@ func TestResourceInstanceIsUpToDate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/resource_groups/", ibmc.RgTestHandler)
-			mux.HandleFunc("/", ibmc.SvcatTestHandler)
-			mux.HandleFunc("/"+ibmc.ServiceNameMockVal+"/", ibmc.PcatTestHandler)
+			mux.HandleFunc("/", ibmc.SvcatTestHandler(tc.args.params.ServiceName))
+			mux.HandleFunc("/"+tc.args.params.ServiceName+"/", ibmc.PcatTestHandler(tc.args.params.ResourcePlanName, *tc.args.instance.ResourcePlanID))
 			mux.HandleFunc("/v3/tags/", ibmc.TagsTestHandler)
 			server := httptest.NewServer(mux)
 			defer server.Close()

--- a/pkg/clients/testutils.go
+++ b/pkg/clients/testutils.go
@@ -28,12 +28,8 @@ import (
 )
 
 var (
-	resourcePlanNameMockVal  = "standard"
 	resourceGroupNameMockVal = "default"
 	resourceGroupIDMockVal   = "0be5ad401ae913d8ff665d92680664ed"
-	resourcePlanIDMockVal    = "2fdf0c08-2d32-4f46-84b5-32e0c92fffd8"
-	// ServiceNameMockVal -
-	ServiceNameMockVal = "cloud-object-storage"
 )
 
 // TagsTestHandler handler to mock client SDK call to global tags API
@@ -66,34 +62,38 @@ var RgTestHandler = func(w http.ResponseWriter, r *http.Request) {
 }
 
 // PcatTestHandler handler to mock client SDK call to global catalog API for plans
-var PcatTestHandler = func(w http.ResponseWriter, r *http.Request) {
-	_ = r.Body.Close()
-	w.Header().Set("Content-Type", "application/json")
-	planEntry := gcat.EntrySearchResult{
-		Resources: []gcat.CatalogEntry{
-			{
-				ID:   reference.ToPtrValue(resourcePlanIDMockVal),
-				Name: reference.ToPtrValue(resourcePlanNameMockVal),
+var PcatTestHandler = func(planName string, planId string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = r.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		planEntry := gcat.EntrySearchResult{
+			Resources: []gcat.CatalogEntry{
+				{
+					Name: reference.ToPtrValue(planName),
+					ID:   reference.ToPtrValue(planId),
+				},
 			},
-		},
+		}
+		_ = json.NewEncoder(w).Encode(planEntry)
 	}
-	_ = json.NewEncoder(w).Encode(planEntry)
 }
 
 // SvcatTestHandler handler to mock client SDK call to global catalog API for services
-var SvcatTestHandler = func(w http.ResponseWriter, r *http.Request) {
-	_ = r.Body.Close()
-	w.Header().Set("Content-Type", "application/json")
-	catEntry := gcat.EntrySearchResult{
-		Resources: []gcat.CatalogEntry{
-			{
-				Metadata: &gcat.CatalogEntryMetadata{
-					UI: &gcat.UIMetaData{
-						PrimaryOfferingID: reference.ToPtrValue(ServiceNameMockVal),
+var SvcatTestHandler = func(serviceName string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = r.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		catEntry := gcat.EntrySearchResult{
+			Resources: []gcat.CatalogEntry{
+				{
+					Metadata: &gcat.CatalogEntryMetadata{
+						UI: &gcat.UIMetaData{
+							PrimaryOfferingID: reference.ToPtrValue(serviceName),
+						},
 					},
 				},
 			},
-		},
+		}
+		_ = json.NewEncoder(w).Encode(catEntry)
 	}
-	_ = json.NewEncoder(w).Encode(catEntry)
 }


### PR DESCRIPTION
### Description of your changes

This PR generalizes the test utilities for the global catalog by allowing the caller to specify the service name, resource plan name, and resource plan ID to be handled.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make test`

[contribution process]: https://git.io/fj2m9
