### PR TITLE
Not using the API key anymore for authentication for S3 buckets - usi…

### DIFF
--- a/examples/cos/create-import-bucket.sh
+++ b/examples/cos/create-import-bucket.sh
@@ -147,8 +147,6 @@ if [[ $rc -ne 0 ]]; then
     echo "-------------" >&2
     
     cat $tmp_file >&2
-else 
-    cat $tmp_file
 fi
 
 rm -f "$tmp_file"

--- a/pkg/clients/groupmembership/groupmembership_test.go
+++ b/pkg/clients/groupmembership/groupmembership_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 var (
-	bearerTok     = "mock-token"
 	accessGroupID = "12345678-abcd-1a2b-a1b2-1234567890ab"
 	createdAt, _  = strfmt.ParseDateTime("2020-10-31T02:33:06Z")
 	transactionID = "12345-abcd-ef000-abac"
@@ -430,7 +429,7 @@ func TestUpdateAccessGroupMembers(t *testing.T) {
 			}
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 

--- a/pkg/clients/ibmcloud_helpers_test.go
+++ b/pkg/clients/ibmcloud_helpers_test.go
@@ -21,10 +21,6 @@ import (
 	rmgrv2 "github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 )
 
-const (
-	bearerTok = "mock-token"
-)
-
 var (
 	resourceGroupID    = "mock-resource-group-id"
 	resourcePlanID     = "744bfc56-d12c-4866-88d5-dac9139e0e5d"
@@ -188,7 +184,7 @@ func TestGetResourcePlanID(t *testing.T) {
 			defer server.Close()
 
 			opts := ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: FakeBearerToken,
 			}}
 			mClient, _ := NewClient(opts)
 
@@ -247,7 +243,7 @@ func TestGetResourcePlanName(t *testing.T) {
 			defer server.Close()
 
 			opts := ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: FakeBearerToken,
 			}}
 			mClient, _ := NewClient(opts)
 
@@ -301,7 +297,7 @@ func TestGetResourceGroupID(t *testing.T) {
 			defer server.Close()
 
 			opts := ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: FakeBearerToken,
 			}}
 			mClient, _ := NewClient(opts)
 
@@ -349,7 +345,7 @@ func TestGetResourceGroupName(t *testing.T) {
 			defer server.Close()
 
 			opts := ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: FakeBearerToken,
 			}}
 			mClient, _ := NewClient(opts)
 
@@ -399,7 +395,7 @@ func TestGetResourceInstanceTags(t *testing.T) {
 			defer server.Close()
 
 			opts := ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: FakeBearerToken,
 			}}
 			mClient, _ := NewClient(opts)
 
@@ -450,7 +446,7 @@ func TestUpdateResourceInstanceTags(t *testing.T) {
 			defer server.Close()
 
 			opts := ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: FakeBearerToken,
 			}}
 			mClient, _ := NewClient(opts)
 

--- a/pkg/clients/resourceinstance/resourceinstance_test.go
+++ b/pkg/clients/resourceinstance/resourceinstance_test.go
@@ -34,10 +34,6 @@ import (
 	ibmc "github.com/crossplane-contrib/provider-ibm-cloud/pkg/clients"
 )
 
-const (
-	bearerTok = "mock-token"
-)
-
 func params(m ...func(*v1alpha1.ResourceInstanceParameters)) *v1alpha1.ResourceInstanceParameters {
 	p := &v1alpha1.ResourceInstanceParameters{
 		Name:              "my-instance",
@@ -212,7 +208,7 @@ func TestGenerateCreateResourceInstanceOptions(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -267,7 +263,7 @@ func TestGenerateUpdateResourceInstanceOptions(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -327,7 +323,7 @@ func TestResourceInstanceLateInitializeSpecs(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -367,7 +363,7 @@ func TestResourceInstanceGenerateObservation(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -424,7 +420,7 @@ func TestResourceInstanceIsUpToDate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 

--- a/pkg/clients/resourcekey/resourcekey_test.go
+++ b/pkg/clients/resourcekey/resourcekey_test.go
@@ -34,10 +34,6 @@ import (
 	ibmc "github.com/crossplane-contrib/provider-ibm-cloud/pkg/clients"
 )
 
-const (
-	bearerTok = "mock-token"
-)
-
 func params(m ...func(*v1alpha1.ResourceKeyParameters)) *v1alpha1.ResourceKeyParameters {
 	p := &v1alpha1.ResourceKeyParameters{
 		Name:   "my-instance-key-1",
@@ -170,7 +166,7 @@ func TestGenerateCreateResourceKeyOptions(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -218,7 +214,7 @@ func TestGenerateUpdateResourceKeyOptions(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -273,7 +269,7 @@ func TestResourceKeyLateInitializeSpecs(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -312,7 +308,7 @@ func TestResourceKeyGenerateObservation(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 
@@ -365,7 +361,7 @@ func TestResourceKeyIsUpToDate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 

--- a/pkg/clients/testutils.go
+++ b/pkg/clients/testutils.go
@@ -32,6 +32,11 @@ var (
 	resourceGroupIDMockVal   = "0be5ad401ae913d8ff665d92680664ed"
 )
 
+// A fake authentication token (WITH the "Bearer " prefix)
+const (
+	FakeBearerToken = "Bearer mock-token"
+)
+
 // TagsTestHandler handler to mock client SDK call to global tags API
 var TagsTestHandler = func(w http.ResponseWriter, r *http.Request) {
 	_ = r.Body.Close()

--- a/pkg/controller/cloudantv1/cloudantdatabase_test.go
+++ b/pkg/controller/cloudantv1/cloudantdatabase_test.go
@@ -44,10 +44,6 @@ import (
 	ibmc "github.com/crossplane-contrib/provider-ibm-cloud/pkg/clients"
 )
 
-const (
-	bearerTok = "mock-token"
-)
-
 var (
 	cdbName = "mycloudantdatabase"
 )
@@ -375,7 +371,7 @@ func TestCloudantDatabaseObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := cloudantdatabaseExternal{
@@ -484,7 +480,7 @@ func TestCloudantDatabaseCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := cloudantdatabaseExternal{
@@ -605,7 +601,7 @@ func TestCloudantDatabaseDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := cloudantdatabaseExternal{

--- a/pkg/controller/cos/bucket_test.go
+++ b/pkg/controller/cos/bucket_test.go
@@ -43,11 +43,6 @@ import (
 	ibmc "github.com/crossplane-contrib/provider-ibm-cloud/pkg/clients"
 )
 
-// Used locally....
-const (
-	bearerTok = "mock-token"
-)
-
 // Constants that we could not use as such because no address...
 var (
 	createdAt                 = metav1.Time{Time: time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)}.Rfc3339Copy()
@@ -196,9 +191,13 @@ func setupServerAndGetUnitTestExternalBucket(testingObj *testing.T, handlers *[]
 
 	tstServer := httptest.NewServer(mux)
 
-	opts := ibmc.ClientOptions{URL: tstServer.URL, Authenticator: &core.BearerTokenAuthenticator{
-		BearerToken: bearerTok,
-	}}
+	opts := ibmc.ClientOptions{
+		URL: tstServer.URL,
+		Authenticator: &core.BearerTokenAuthenticator{
+			BearerToken: ibmc.FakeBearerToken,
+		},
+		BearerToken: ibmc.FakeBearerToken,
+	}
 
 	mClient, errNC := ibmc.NewClient(opts)
 	if errNC != nil {

--- a/pkg/controller/eventstreamsadminv1/topic_test.go
+++ b/pkg/controller/eventstreamsadminv1/topic_test.go
@@ -44,10 +44,6 @@ import (
 	ibmc "github.com/crossplane-contrib/provider-ibm-cloud/pkg/clients"
 )
 
-const (
-	bearerTok = "mock-token"
-)
-
 var (
 	tName = "myTopic"
 )
@@ -465,7 +461,7 @@ func TestTopicObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := topicExternal{
@@ -574,7 +570,7 @@ func TestTopicCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := topicExternal{
@@ -695,7 +691,7 @@ func TestTopicDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := topicExternal{
@@ -796,7 +792,7 @@ func TestTopicUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := topicExternal{

--- a/pkg/controller/iamaccessgroupsv2/accessgroup_test.go
+++ b/pkg/controller/iamaccessgroupsv2/accessgroup_test.go
@@ -46,7 +46,6 @@ import (
 )
 
 const (
-	bearerTok       = "mock-token"
 	errAgBadRequest = "error getting access group: Bad Request"
 	errAgForbidden  = "error getting access group: Forbidden"
 )
@@ -353,7 +352,7 @@ func TestAccessGroupObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agExternal{
@@ -514,7 +513,7 @@ func TestAccessGroupCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agExternal{
@@ -657,7 +656,7 @@ func TestAccessGroupDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agExternal{
@@ -779,7 +778,7 @@ func TestAccessGroupUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agExternal{

--- a/pkg/controller/iamaccessgroupsv2/accessgrouprule_test.go
+++ b/pkg/controller/iamaccessgroupsv2/accessgrouprule_test.go
@@ -354,7 +354,7 @@ func TestAccessGroupRuleObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agrExternal{
@@ -515,7 +515,7 @@ func TestAccessGroupRuleCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agrExternal{
@@ -658,7 +658,7 @@ func TestAccessGroupRuleDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agrExternal{
@@ -780,7 +780,7 @@ func TestAccessGroupRuleUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := agrExternal{

--- a/pkg/controller/iamaccessgroupsv2/groupmembership_test.go
+++ b/pkg/controller/iamaccessgroupsv2/groupmembership_test.go
@@ -417,7 +417,7 @@ func TestGroupMembershipObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := gmExternal{
@@ -578,7 +578,7 @@ func TestGroupMembershipCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := gmExternal{
@@ -722,7 +722,7 @@ func TestGroupMembershipDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := gmExternal{
@@ -872,7 +872,7 @@ func TestGroupMembershipUpdate(t *testing.T) {
 			}
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := gmExternal{

--- a/pkg/controller/iampolicymanagementv1/customrole_test.go
+++ b/pkg/controller/iampolicymanagementv1/customrole_test.go
@@ -349,7 +349,7 @@ func TestCustomRoleObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := crExternal{
@@ -510,7 +510,7 @@ func TestCustomRoleCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := crExternal{
@@ -653,7 +653,7 @@ func TestCustomRoleDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := crExternal{
@@ -775,7 +775,7 @@ func TestCustomRoleUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := crExternal{

--- a/pkg/controller/iampolicymanagementv1/policy_test.go
+++ b/pkg/controller/iampolicymanagementv1/policy_test.go
@@ -45,7 +45,6 @@ import (
 )
 
 const (
-	bearerTok     = "mock-token"
 	errBadRequest = "error getting policy: Bad Request"
 	errForbidden  = "error getting policy: Forbidden"
 )
@@ -427,7 +426,7 @@ func TestPolicyObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := pExternal{
@@ -588,7 +587,7 @@ func TestPolicyCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := pExternal{
@@ -731,7 +730,7 @@ func TestPolicyDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := pExternal{
@@ -853,7 +852,7 @@ func TestPolicyUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := pExternal{

--- a/pkg/controller/ibmclouddatabasesv5/autoscalinggroup_test.go
+++ b/pkg/controller/ibmclouddatabasesv5/autoscalinggroup_test.go
@@ -398,7 +398,7 @@ func TestAutoscalingGroupObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := asgExternal{
@@ -481,7 +481,7 @@ func TestAutoscalingGroupCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := asgExternal{
@@ -558,7 +558,7 @@ func TestAutoscalingGroupDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := asgExternal{
@@ -658,7 +658,7 @@ func TestAutoscalingGroupUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := asgExternal{

--- a/pkg/controller/ibmclouddatabasesv5/scalinggroup_test.go
+++ b/pkg/controller/ibmclouddatabasesv5/scalinggroup_test.go
@@ -43,7 +43,6 @@ import (
 )
 
 const (
-	bearerTok     = "mock-token"
 	errBadRequest = "error getting instance: Bad Request"
 	errForbidden  = "error getting instance: Forbidden"
 	wtfConst      = "crossplane.io/external-name"
@@ -448,7 +447,7 @@ func TestScalingGroupObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := sgExternal{
@@ -531,7 +530,7 @@ func TestScalingGroupCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := sgExternal{
@@ -608,7 +607,7 @@ func TestScalingGroupDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := sgExternal{
@@ -708,7 +707,7 @@ func TestScalingGroupUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := sgExternal{

--- a/pkg/controller/ibmclouddatabasesv5/whitelist_test.go
+++ b/pkg/controller/ibmclouddatabasesv5/whitelist_test.go
@@ -315,7 +315,7 @@ func TestWhitelistObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := wlExternal{
@@ -397,7 +397,7 @@ func TestWhitelistCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := wlExternal{
@@ -475,7 +475,7 @@ func TestWhitelistDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := wlExternal{
@@ -574,7 +574,7 @@ func TestWhitelistUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := wlExternal{

--- a/pkg/controller/resourcecontrollerv2/resourceinstance_test.go
+++ b/pkg/controller/resourcecontrollerv2/resourceinstance_test.go
@@ -50,7 +50,6 @@ import (
 )
 
 const (
-	bearerTok  = "mock-token"
 	wtfConst   = "crossplane.io/external-name"
 	errNoRCDep = "No RC deployments for plan: standard with target wrong-target"
 )
@@ -503,7 +502,7 @@ func TestObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourceinstanceExternal{
@@ -651,7 +650,7 @@ func TestCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourceinstanceExternal{
@@ -772,7 +771,7 @@ func TestDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourceinstanceExternal{
@@ -889,7 +888,7 @@ func TestUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourceinstanceExternal{

--- a/pkg/controller/resourcecontrollerv2/resourcekey_test.go
+++ b/pkg/controller/resourcecontrollerv2/resourcekey_test.go
@@ -387,7 +387,7 @@ func TestResourceKeyObserve(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourcekeyExternal{
@@ -507,7 +507,7 @@ func TestResourceKeyCreate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourcekeyExternal{
@@ -628,7 +628,7 @@ func TestResourceKeyDelete(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourcekeyExternal{
@@ -728,7 +728,7 @@ func TestResourceKeyUpdate(t *testing.T) {
 			defer server.Close()
 
 			opts := ibmc.ClientOptions{URL: server.URL, Authenticator: &core.BearerTokenAuthenticator{
-				BearerToken: bearerTok,
+				BearerToken: ibmc.FakeBearerToken,
 			}}
 			mClient, _ := ibmc.NewClient(opts)
 			e := resourcekeyExternal{


### PR DESCRIPTION
…ng only tokens

Signed-off-by: Harry Stavropoulos <hstavrop@us.ibm.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Now using a different API call to authenticate, which does not require the API key.

Also some doc changes, to make clear what format of Bearer tokens is expected, and some refactoring in the testing code (the testing bearer token is now specified at one place)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #59

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

"manually" against the IBM cloud + unit tests

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
